### PR TITLE
Use Field default factories for PatientData model

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from app.hoop_engine import hoop_engine
 
 app = FastAPI()
@@ -9,13 +9,13 @@ def read_root():
     return {"message": "MediNote API is live 🚀"}
 
 class PatientData(BaseModel):
-    POC_glucose: list = []
-    active_meds: list = []
-    meal_percent: list = []
-    labs: dict = {}
-    vitals: dict = {}
-    problems: list = []
-    ICD10: list = []
+    POC_glucose: list = Field(default_factory=list)
+    active_meds: list = Field(default_factory=list)
+    meal_percent: list = Field(default_factory=list)
+    labs: dict = Field(default_factory=dict)
+    vitals: dict = Field(default_factory=dict)
+    problems: list = Field(default_factory=list)
+    ICD10: list = Field(default_factory=list)
 
 @app.post("/generate-note")
 async def generate_note(data: PatientData):


### PR DESCRIPTION
## Summary
- Import `Field` from Pydantic in `app/main.py`
- Replace mutable defaults in `PatientData` with `Field` default factories to avoid shared state

## Testing
- `pytest`
- `uvicorn app.main:app --port 8000` and curl GET `/` and POST `/generate-note`

------
https://chatgpt.com/codex/tasks/task_b_689dbd44c9a0832b83efd3c8c6655c94