### PR TITLE
Summarize meal intake in assessment plan

### DIFF
--- a/app/hoop_engine.py
+++ b/app/hoop_engine.py
@@ -28,6 +28,14 @@ def hoop_engine(data):
         glucose_values = ", ".join(str(g) for g in data["POC_glucose"])
         assessment_plan.append(f"POC Glucose readings: {glucose_values} mg/dL.")
 
+    # Add meal intake summary
+    if data.get("meal_percent"):
+        meal_values = data["meal_percent"]
+        avg_intake = sum(meal_values) / len(meal_values)
+        assessment_plan.append(
+            f"Average meal intake: {avg_intake:.1f}% over the last {len(meal_values)} meals."
+        )
+
     # Generic plan
     assessment_plan.append("Plan: Continue current management, encourage healthy diet and exercise, follow up in 3 months.")
 

--- a/tests/test_meal_percent.py
+++ b/tests/test_meal_percent.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.hoop_engine import hoop_engine
+
+
+def test_meal_percent_in_assessment_plan():
+    with open('data/patient_sample.json') as f:
+        sample_data = json.load(f)
+
+    result = hoop_engine(sample_data)
+    assert any('Average meal intake' in item for item in result['assessment_plan'])
+


### PR DESCRIPTION
## Summary
- Include average meal intake percentage in assessment plan generation
- Add test ensuring meal intake summary appears when meal data provided

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest`


------
https://chatgpt.com/codex/tasks/task_b_689dbd46c25c832bb4428a0942ae5039