### PR TITLE
Add pytest tests for hoop_engine and generate-note endpoint

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,17 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: pip install pytest httpx
+      - run: pytest

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# MediNote Backend
+
+Simple FastAPI service for generating patient notes.
+
+## Running Tests
+
+Install dependencies and execute the test suite with:
+
+```bash
+pip install -r requirements.txt
+pip install pytest httpx
+pytest
+```
+
+These tests cover both the core `hoop_engine` logic and the `/generate-note` API endpoint using the sample patient data.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for imports
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_generate_note.py
+++ b/tests/test_generate_note.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def load_sample():
+    data_path = Path(__file__).resolve().parents[1] / "data" / "patient_sample.json"
+    with open(data_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_generate_note_endpoint_returns_plan():
+    client = TestClient(app)
+    sample = load_sample()
+
+    response = client.post("/generate-note", json=sample)
+    assert response.status_code == 200
+    data = response.json()
+
+    assessment_text = " ".join(data["assessment_plan"])
+    for phrase in [
+        "Patient presents with",
+        "POC Glucose readings",
+        "Plan: Continue current management",
+    ]:
+        assert phrase in assessment_text

--- a/tests/test_hoop_engine.py
+++ b/tests/test_hoop_engine.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+from app.hoop_engine import hoop_engine
+
+
+def load_sample():
+    data_path = Path(__file__).resolve().parents[1] / "data" / "patient_sample.json"
+    with open(data_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_hoop_engine_generates_assessment_plan():
+    sample = load_sample()
+    result = hoop_engine(sample)
+
+    assert "assessment_plan" in result
+    assessment_text = " ".join(result["assessment_plan"])
+
+    for phrase in [
+        "Patient presents with",
+        "Current medications",
+        "Plan: Continue current management",
+    ]:
+        assert phrase in assessment_text


### PR DESCRIPTION
## Summary
- add pytest tests for core hoop_engine logic and /generate-note route
- document how to run the test suite
- configure GitHub Actions to run tests on pushes and PRs

## Testing
- `pytest tests/test_hoop_engine.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx)*

------
https://chatgpt.com/codex/tasks/task_b_689cf5b60724832bab206a2a556216ab