### PR TITLE
feat: summarize meal intake

### DIFF
--- a/app/hoop_engine.py
+++ b/app/hoop_engine.py
@@ -28,6 +28,13 @@ def hoop_engine(data):
         glucose_values = ", ".join(str(g) for g in data["POC_glucose"])
         assessment_plan.append(f"POC Glucose readings: {glucose_values} mg/dL.")
 
+    # Add meal intake percentage
+    if data.get("meal_percent"):
+        avg_intake = sum(data["meal_percent"]) / len(data["meal_percent"])
+        assessment_plan.append(
+            f"Average meal intake: {avg_intake:.1f}%."
+        )
+
     # Generic plan
     assessment_plan.append("Plan: Continue current management, encourage healthy diet and exercise, follow up in 3 months.")
 

--- a/tests/test_hoop_engine.py
+++ b/tests/test_hoop_engine.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.hoop_engine import hoop_engine
+
+
+def test_meal_percent_summary():
+    data = {"meal_percent": [60, 40]}
+    result = hoop_engine(data)
+    assert any("Average meal intake" in line for line in result["assessment_plan"])
+    assert any("50.0%" in line for line in result["assessment_plan"])


### PR DESCRIPTION
## Summary
- summarize meal_percent entries into an average meal intake line
- cover meal intake summarization with regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689cf5b45b88832ba0bc3f9fff53c8f1