### PR TITLE
Add CORS middleware to FastAPI app

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,17 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+
 from app.hoop_engine import hoop_engine
 
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 @app.get("/")
 def read_root():


### PR DESCRIPTION
## Summary
- enable CORS for React dev server to allow cross-origin requests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689dc57eec50832bb03aa8df2b99160a