### PR TITLE
Add React context with persistent patient and note state

### DIFF
--- a/frontend/src/state.js
+++ b/frontend/src/state.js
@@ -1,0 +1,49 @@
+import { createContext, useContext, useState, useEffect } from 'react';
+
+const AppStateContext = createContext();
+
+export const AppStateProvider = ({ children }) => {
+  const [patientData, setPatientData] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem('patientData')) || {};
+    } catch {
+      return {};
+    }
+  });
+
+  const [note, setNote] = useState(() => localStorage.getItem('note') || '');
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('patientData', JSON.stringify(patientData));
+    } catch {
+      // ignore write errors
+    }
+  }, [patientData]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('note', note);
+    } catch {
+      // ignore write errors
+    }
+  }, [note]);
+
+  return (
+    <AppStateContext.Provider value={{ patientData, setPatientData, note, setNote }}>
+      {children}
+    </AppStateContext.Provider>
+  );
+};
+
+export const usePatientData = () => {
+  const { patientData, setPatientData } = useContext(AppStateContext);
+  return [patientData, setPatientData];
+};
+
+export const useNote = () => {
+  const { note, setNote } = useContext(AppStateContext);
+  return [note, setNote];
+};
+
+export default AppStateContext;


### PR DESCRIPTION
## Summary
- add React context provider to store patient data and note output
- include hooks `usePatientData` and `useNote`
- persist state in `localStorage`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a35182cd34832b855aec9b4264da2f