### PR TITLE
Add Node test harness for hoop engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+node_modules/

--- a/hoopEngine.js
+++ b/hoopEngine.js
@@ -1,0 +1,31 @@
+function hoopEngine(data) {
+  const assessmentPlan = [];
+  if (data.problems && data.problems.length) {
+    assessmentPlan.push(`Patient presents with: ${data.problems.join(', ')}.`);
+  }
+  if (data.labs && Object.keys(data.labs).length) {
+    const labsSummary = Object.entries(data.labs)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join(', ');
+    assessmentPlan.push(`Recent labs: ${labsSummary}.`);
+  }
+  if (data.vitals && Object.keys(data.vitals).length) {
+    const vitalsSummary = Object.entries(data.vitals)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join(', ');
+    assessmentPlan.push(`Vitals: ${vitalsSummary}.`);
+  }
+  if (data.active_meds && data.active_meds.length) {
+    assessmentPlan.push(`Current medications: ${data.active_meds.join(', ')}.`);
+  }
+  if (data.POC_glucose && data.POC_glucose.length) {
+    const glucoseValues = data.POC_glucose.join(', ');
+    assessmentPlan.push(`POC Glucose readings: ${glucoseValues} mg/dL.`);
+  }
+  assessmentPlan.push(
+    'Plan: Continue current management, encourage healthy diet and exercise, follow up in 3 months.'
+  );
+  return { ...data, assessment_plan: assessmentPlan };
+}
+
+module.exports = { hoopEngine };

--- a/hoopEngine.test.js
+++ b/hoopEngine.test.js
@@ -1,0 +1,20 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { hoopEngine } = require('./hoopEngine');
+
+test('builds assessment plan from data', () => {
+  const data = {
+    problems: ['Hypertension'],
+    labs: { A1C: '7%' },
+    vitals: { BP: '120/80' },
+    active_meds: ['Metformin'],
+    POC_glucose: [110, 115],
+  };
+  const result = hoopEngine(data);
+  assert.ok(result.assessment_plan.includes('Patient presents with: Hypertension.'));
+  assert.ok(result.assessment_plan.includes('Recent labs: A1C: 7%.'));
+  assert.ok(result.assessment_plan.includes('Vitals: BP: 120/80.'));
+  assert.ok(result.assessment_plan.includes('Current medications: Metformin.'));
+  assert.ok(result.assessment_plan.includes('POC Glucose readings: 110, 115 mg/dL.'));
+  assert.ok(result.assessment_plan.includes('Plan: Continue current management, encourage healthy diet and exercise, follow up in 3 months.'));
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "medinote_backend",
+  "version": "1.0.0",
+  "description": "FastAPI backend for generating clinical notes.",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- add JavaScript implementation of hoopEngine and node:test coverage
- configure npm test to run Node's built-in test runner
- ignore node_modules in git

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a3906a7b08832b8d554ae897bb9be6