### PR TITLE
feat: add client-side validation

### DIFF
--- a/frontend/form.js
+++ b/frontend/form.js
@@ -1,0 +1,50 @@
+const form = document.getElementById('patient-form');
+const fields = ['name', 'age', 'email'];
+
+const schema = yup.object({
+  name: yup.string().required('Name is required'),
+  age: yup.number().typeError('Age must be a number').required('Age is required'),
+  email: yup.string().email('Invalid email').required('Email is required'),
+});
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  clearErrors();
+  const data = {
+    name: form.name.value.trim(),
+    age: form.age.value,
+    email: form.email.value.trim(),
+  };
+  try {
+    await schema.validate(data, { abortEarly: false });
+    const response = await fetch('/generate-note', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(message || 'Request failed');
+    }
+    document.getElementById('serverError').textContent = 'Note generated successfully';
+  } catch (err) {
+    if (err.name === 'ValidationError') {
+      err.inner.forEach(({ path, message }) => {
+        const input = document.getElementById(path);
+        input.classList.add('error');
+        document.getElementById(`${path}Error`).textContent = message;
+      });
+    } else {
+      document.getElementById('serverError').textContent = `Error: ${err.message}`;
+    }
+  }
+});
+
+function clearErrors() {
+  fields.forEach((field) => {
+    const input = document.getElementById(field);
+    input.classList.remove('error');
+    document.getElementById(`${field}Error`).textContent = '';
+  });
+  document.getElementById('serverError').textContent = '';
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>MediNote Patient Form</title>
+  <style>
+    .error { border-color: red; }
+    .error-message { color: red; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <form id="patient-form">
+    <div>
+      <label for="name">Name</label>
+      <input type="text" id="name" />
+      <span id="nameError" class="error-message"></span>
+    </div>
+    <div>
+      <label for="age">Age</label>
+      <input type="number" id="age" />
+      <span id="ageError" class="error-message"></span>
+    </div>
+    <div>
+      <label for="email">Email</label>
+      <input type="email" id="email" />
+      <span id="emailError" class="error-message"></span>
+    </div>
+    <button type="submit">Submit</button>
+  </form>
+  <div id="serverError" class="error-message"></div>
+  <script src="https://cdn.jsdelivr.net/npm/yup@1.2.0/dist/yup.min.js"></script>
+  <script src="form.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add a simple HTML form with Yup-powered validation for patient data
- Show user-friendly errors for failed HTTP calls
- Highlight fields with validation errors for better UX

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a3518017e4832bb7e6a7fd1b3fd3b2