### PR TITLE
Add frontend note viewer with copy feature

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,6 @@
 from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from pathlib import Path
 from pydantic import BaseModel
 from app.hoop_engine import hoop_engine
 
@@ -7,6 +9,13 @@ app = FastAPI()
 @app.get("/")
 def read_root():
     return {"message": "MediNote API is live 🚀"}
+
+
+@app.get("/note", response_class=HTMLResponse)
+def note_page() -> HTMLResponse:
+    """Serve a simple page for generating notes."""
+    html_path = Path(__file__).resolve().parent / "templates" / "note.html"
+    return HTMLResponse(html_path.read_text())
 
 class PatientData(BaseModel):
     POC_glucose: list = []

--- a/app/templates/note.html
+++ b/app/templates/note.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>MediNote Generator</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    textarea { width: 100%; box-sizing: border-box; padding: 1rem; font-family: monospace; }
+    #note { height: 200px; }
+  </style>
+</head>
+<body>
+  <h1>MediNote Generator</h1>
+  <form id="patient-form">
+    <label for="data">Patient Data (JSON)</label>
+    <textarea id="data" rows="8" placeholder='{"problems": ["hypertension"]}'></textarea>
+    <button type="submit">Submit</button>
+  </form>
+
+  <h2>Assessment &amp; Plan</h2>
+  <textarea id="note" readonly></textarea>
+  <button id="copy-btn">Copy to Clipboard</button>
+
+  <script>
+    document.getElementById('patient-form').addEventListener('submit', async function(e) {
+      e.preventDefault();
+      const text = document.getElementById('data').value;
+      let payload;
+      try {
+        payload = JSON.parse(text);
+      } catch (err) {
+        alert('Invalid JSON');
+        return;
+      }
+      const res = await fetch('/generate-note', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(payload)
+      });
+      const json = await res.json();
+      const note = Array.isArray(json.assessment_plan) ? json.assessment_plan.join('\n') : '';
+      const noteEl = document.getElementById('note');
+      noteEl.value = note;
+    });
+
+    document.getElementById('copy-btn').addEventListener('click', async function() {
+      const noteEl = document.getElementById('note');
+      await navigator.clipboard.writeText(noteEl.value);
+    });
+  </script>
+</body>
+</html>

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_note_page_contains_textarea_and_copy_button():
+    response = client.get("/note")
+    assert response.status_code == 200
+    html = response.text
+    assert "id=\"note\"" in html
+    assert "copy-btn" in html


### PR DESCRIPTION
## Summary
- serve new `/note` page to interact with note generation API
- parse `/generate-note` responses in-browser and show in styled textarea
- add convenient copy-to-clipboard button

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a3517f1380832b934edfd5dd200de3