### PR TITLE
feat: scaffold Next.js frontend

### DIFF
--- a/medinote-frontend/.eslintrc.json
+++ b/medinote-frontend/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/medinote-frontend/.gitignore
+++ b/medinote-frontend/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+out
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.DS_Store

--- a/medinote-frontend/next-env.d.ts
+++ b/medinote-frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/medinote-frontend/next.config.js
+++ b/medinote-frontend/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/medinote-frontend/package.json
+++ b/medinote-frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "medinote-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "typescript": "5.5.3",
+    "@types/react": "18.2.14",
+    "@types/node": "20.10.5",
+    "@types/react-dom": "18.2.7",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3"
+  }
+}

--- a/medinote-frontend/pages/index.tsx
+++ b/medinote-frontend/pages/index.tsx
@@ -1,0 +1,59 @@
+import { useState, FormEvent } from 'react';
+
+export default function Home() {
+  const [vitals, setVitals] = useState('');
+  const [labs, setLabs] = useState('');
+  const [meds, setMeds] = useState('');
+  const [symptoms, setSymptoms] = useState('');
+  const [note, setNote] = useState('');
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const payload = {
+      vitals: { notes: vitals },
+      labs: { notes: labs },
+      active_meds: meds.split(',').map(m => m.trim()).filter(Boolean),
+      problems: symptoms.split(',').map(s => s.trim()).filter(Boolean)
+    };
+
+    try {
+      const res = await fetch('http://localhost:8000/generate-note', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      const data = await res.json();
+      setNote(JSON.stringify(data, null, 2));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <main style={{ padding: '2rem' }}>
+      <h1>MediNote</h1>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1rem', maxWidth: '600px' }}>
+        <label>
+          Vitals
+          <textarea value={vitals} onChange={e => setVitals(e.target.value)} />
+        </label>
+        <label>
+          Labs
+          <textarea value={labs} onChange={e => setLabs(e.target.value)} />
+        </label>
+        <label>
+          Meds (comma separated)
+          <textarea value={meds} onChange={e => setMeds(e.target.value)} />
+        </label>
+        <label>
+          Symptoms (comma separated)
+          <textarea value={symptoms} onChange={e => setSymptoms(e.target.value)} />
+        </label>
+        <button type="submit">Generate Note</button>
+      </form>
+      {note && (
+        <pre style={{ marginTop: '2rem', whiteSpace: 'pre-wrap' }}>{note}</pre>
+      )}
+    </main>
+  );
+}

--- a/medinote-frontend/tsconfig.json
+++ b/medinote-frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js TypeScript app
- add vitals, labs, meds, and symptoms form posting to backend `/generate-note`

## Testing
- `npm test`
- `npm run build` *(fails: next not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a3517db848832b89ca80db709e890e