### PR TITLE
Refactor hoop engine with helpers and configurable sections

### DIFF
--- a/tests/test_hoop_engine.py
+++ b/tests/test_hoop_engine.py
@@ -23,3 +23,23 @@ def test_hoop_engine_generates_assessment_plan():
     assert any("bacteremia" in item for item in plan)
     assert any("Recent labs" in item for item in plan)
     assert any("POC Glucose readings" in item for item in plan)
+
+
+def test_hoop_engine_optional_sections():
+    data = load_sample_data()
+    result = hoop_engine(data, include_sections=["labs"])
+    plan = result.get("assessment_plan", [])
+
+    assert any("Recent labs" in item for item in plan)
+    assert all("Vitals" not in item for item in plan)
+    assert all("Patient presents with" not in item for item in plan)
+
+
+def test_hoop_engine_custom_plan():
+    data = load_sample_data()
+    custom_plan = ["Plan: Start antibiotics."]
+    result = hoop_engine(data, plan=custom_plan)
+    plan = result.get("assessment_plan", [])
+
+    assert custom_plan[0] in plan
+    assert not any("Continue current management" in item for item in plan)


### PR DESCRIPTION
## Summary
- modularize assessment generation into helper functions
- allow selective section inclusion and custom plans in `hoop_engine`
- expand test coverage for optional sections and configurable plans

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a351770100832b86c662d43f2e122f