### PR TITLE
feat: modular note generator

### DIFF
--- a/app/hoop_engine.py
+++ b/app/hoop_engine.py
@@ -1,38 +1,23 @@
+"""Core engine for generating patient notes."""
+
+from .note_generator import generate_assessment_plan
+
+
 def hoop_engine(data):
+    """Create a response containing an assessment & plan.
+
+    Parameters
+    ----------
+    data:
+        Patient information to be fed to the note generator.
+
+    Returns
+    -------
+    dict
+        Original data augmented with ``assessment_plan`` key.
     """
-    Takes patient data and returns an assessment & plan.
-    """
 
-    assessment_plan = []
+    assessment_plan = generate_assessment_plan(data)
 
-    # Add problems
-    if data.get("problems"):
-        assessment_plan.append(f"Patient presents with: {', '.join(data['problems'])}.")
-
-    # Add labs
-    if data.get("labs"):
-        labs_summary = ", ".join(f"{k}: {v}" for k, v in data["labs"].items())
-        assessment_plan.append(f"Recent labs: {labs_summary}.")
-
-    # Add vitals
-    if data.get("vitals"):
-        vitals_summary = ", ".join(f"{k}: {v}" for k, v in data["vitals"].items())
-        assessment_plan.append(f"Vitals: {vitals_summary}.")
-
-    # Add meds
-    if data.get("active_meds"):
-        assessment_plan.append(f"Current medications: {', '.join(data['active_meds'])}.")
-
-    # Add POC glucose
-    if data.get("POC_glucose"):
-        glucose_values = ", ".join(str(g) for g in data["POC_glucose"])
-        assessment_plan.append(f"POC Glucose readings: {glucose_values} mg/dL.")
-
-    # Generic plan
-    assessment_plan.append("Plan: Continue current management, encourage healthy diet and exercise, follow up in 3 months.")
-
-    return {
-        **data,
-        "assessment_plan": assessment_plan
-    }
+    return {**data, "assessment_plan": assessment_plan}
 

--- a/app/note_generator.py
+++ b/app/note_generator.py
@@ -1,0 +1,112 @@
+"""Utilities for generating assessment and plan text.
+
+This module supports multiple strategies for crafting assessment and plan
+notes. Strategy is selected via the ``NOTE_STRATEGY`` environment variable
+(default: ``"rule"``). Additional configuration such as API keys or model
+choices are also read from environment variables.
+
+Currently supported strategies:
+
+* ``rule`` - basic rule-based generator (default)
+* ``llm`` - uses OpenAI's API via the ``openai`` package
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List
+
+
+def generate_assessment_plan(data: Dict) -> List[str]:
+    """Generate an assessment & plan based on ``data``.
+
+    Parameters
+    ----------
+    data:
+        Patient data dictionary containing problems, labs, vitals, etc.
+
+    Returns
+    -------
+    list[str]
+        A list of assessment and plan strings.
+    """
+
+    strategy = os.getenv("NOTE_STRATEGY", "rule").lower()
+    if strategy == "llm":
+        return _generate_llm_plan(data)
+    return _generate_rule_based_plan(data)
+
+
+def _generate_rule_based_plan(data: Dict) -> List[str]:
+    """Simple rule-based generator mirroring original behaviour."""
+    assessment_plan: List[str] = []
+
+    if data.get("problems"):
+        assessment_plan.append(
+            f"Patient presents with: {', '.join(data['problems'])}."
+        )
+
+    if data.get("labs"):
+        labs_summary = ", ".join(f"{k}: {v}" for k, v in data["labs"].items())
+        assessment_plan.append(f"Recent labs: {labs_summary}.")
+
+    if data.get("vitals"):
+        vitals_summary = ", ".join(
+            f"{k}: {v}" for k, v in data["vitals"].items()
+        )
+        assessment_plan.append(f"Vitals: {vitals_summary}.")
+
+    if data.get("active_meds"):
+        assessment_plan.append(
+            f"Current medications: {', '.join(data['active_meds'])}."
+        )
+
+    if data.get("POC_glucose"):
+        glucose_values = ", ".join(str(g) for g in data["POC_glucose"])
+        assessment_plan.append(
+            f"POC Glucose readings: {glucose_values} mg/dL."
+        )
+
+    assessment_plan.append(
+        "Plan: Continue current management, encourage healthy diet and "
+        "exercise, follow up in 3 months."
+    )
+
+    return assessment_plan
+
+
+def _generate_llm_plan(data: Dict) -> List[str]:
+    """Generate plan text using an LLM via the OpenAI API.
+
+    The API key is read from ``NOTE_LLM_API_KEY`` or ``OPENAI_API_KEY``.
+    The model defaults to ``gpt-3.5-turbo`` but can be overridden via the
+    ``NOTE_LLM_MODEL`` environment variable.
+    """
+
+    api_key = os.getenv("NOTE_LLM_API_KEY") or os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "LLM strategy selected but no API key provided in NOTE_LLM_API_KEY "
+            "or OPENAI_API_KEY"
+        )
+
+    model = os.getenv("NOTE_LLM_MODEL", "gpt-3.5-turbo")
+
+    try:
+        import openai  # type: ignore
+    except Exception as exc:  # pragma: no cover - import error tested implicitly
+        raise RuntimeError("openai package is required for LLM strategy") from exc
+
+    openai.api_key = api_key
+    prompt = (
+        "Generate a concise medical assessment and plan based on the following "
+        f"patient data: {data}"
+    )
+    response = openai.ChatCompletion.create(
+        model=model, messages=[{"role": "user", "content": prompt}]
+    )
+    text = response["choices"][0]["message"]["content"].strip()
+    return [text]
+
+
+__all__ = ["generate_assessment_plan"]

--- a/tests/test_hoop_engine.py
+++ b/tests/test_hoop_engine.py
@@ -7,6 +7,7 @@ if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))
 
 from app.hoop_engine import hoop_engine
+from app.note_generator import generate_assessment_plan
 
 
 def load_sample_data():
@@ -15,10 +16,21 @@ def load_sample_data():
         return json.load(f)
 
 
-def test_hoop_engine_generates_assessment_plan():
+def test_hoop_engine_generates_assessment_plan(monkeypatch):
     data = load_sample_data()
+    monkeypatch.setenv("NOTE_STRATEGY", "rule")
     result = hoop_engine(data)
     plan = result.get("assessment_plan", [])
+
+    assert any("bacteremia" in item for item in plan)
+    assert any("Recent labs" in item for item in plan)
+    assert any("POC Glucose readings" in item for item in plan)
+
+
+def test_note_generator_rule_based(monkeypatch):
+    data = load_sample_data()
+    monkeypatch.setenv("NOTE_STRATEGY", "rule")
+    plan = generate_assessment_plan(data)
 
     assert any("bacteremia" in item for item in plan)
     assert any("Recent labs" in item for item in plan)


### PR DESCRIPTION
## Summary
- add configurable note generator supporting rule-based and LLM strategies
- route hoop_engine through new generator
- test note generator output and configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a34049be5c832bb641bd7ec7ee2c6f